### PR TITLE
Color related patch

### DIFF
--- a/elegantbook-cn.tex
+++ b/elegantbook-cn.tex
@@ -89,40 +89,40 @@ Elegant\LaTeX{} 项目组致力于打造一系列美观、优雅、简便的模�
                   >{\colorset{gray}}c  
                   >{\colorset{black}}cc}
 \toprule
-	        & \textcolor{structure}{green} 
-	        & \textcolor{structure}{cyan} 
-	        & \textcolor{structure}{blue} 
-	        & \textcolor{structure}{gray} 
-	        & \textcolor{structure}{black}
-	        & 主要使用的环境 \\
+          & \textcolor{structure}{green} 
+          & \textcolor{structure}{cyan} 
+          & \textcolor{structure}{blue} 
+          & \textcolor{structure}{gray} 
+          & \textcolor{structure}{black}
+          & 主要使用的环境 \\
 \midrule
 structure & \colorDemo{structure}
-  				& \colorDemo{structure}
-  				& \colorDemo{structure} 
-  				& \colorDemo{structure} 
-  				& \colorDemo{structure} 
-  				& chapter \ section \ subsection \\
+          & \colorDemo{structure}
+          & \colorDemo{structure} 
+          & \colorDemo{structure} 
+          & \colorDemo{structure} 
+          & chapter \ section \ subsection \\
 
 main      & \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-  				& definition \ exercise \ problem \\
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & definition \ exercise \ problem \\
 
 second    & \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-  				& theorem \ lemma \ corollary\\
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & theorem \ lemma \ corollary\\
 
 third     & \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-  				& proposition \\
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & proposition \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -364,9 +364,9 @@ Lebesgue 积分有几种不同的定义方式。我们将采用逐步定义非�
 我们知道最小二乘法可以用来处理一组数据，可以从一组测定的数据中寻求变量之间的依赖关系，这种函数关系称为经验公式。本课题将介绍最小二乘法的精确定义及如何寻求点与点之间近似成线性关系时的经验公式。假定实验测得变量之间的 $n$ 个数据，则在平面上，可以得到 $n$ 个点，这种图形称为 “散点图”，从图中可以粗略看出这些点大致散落在某直线近旁, 我们认为其近似为一线性函数，下面介绍求解步骤。
 
 \begin{figure}[htbp]
-	\centering
-	\includegraphics[width=0.6\textwidth]{scatter.pdf}
-	\caption{散点图示例 $\hat{y}=a+bx$ \label{fig:scatter}}
+  \centering
+  \includegraphics[width=0.6\textwidth]{scatter.pdf}
+  \caption{散点图示例 $\hat{y}=a+bx$ \label{fig:scatter}}
 \end{figure}
 
 以最简单的一元线性模型来解释最小二乘法。什么是一元线性模型呢？监督学习中，如果预测的变量是离散的，我们称其为分类（如决策树，支持向量机等），如果预测的变量是连续的，我们称其为回归。回归分析中，如果只包括一个自变量和一个因变量，且二者的关系可用一条直线近似表示，这种回归分析称为一元线性回归分析。如果回归分析中包括两个或两个以上的自变量，且因变量和自变量之间是线性关系，则称为多元线性回归分析。对于二维空间线性是一条直线；对于三维空间线性是一个平面，对于多维空间线性是一个超平面。

--- a/elegantbook-en.tex
+++ b/elegantbook-en.tex
@@ -89,37 +89,37 @@ This template contains 5 color themes,they are  \colorsetDemo{green}\footnote{or
                   >{\colorset{gray}}c  
                   >{\colorset{black}}cc}
 \toprule
-	        & \textcolor{structure}{green} 
-	        & \textcolor{structure}{cyan} 
-	        & \textcolor{structure}{blue} 
-	        & \textcolor{structure}{gray} 
-	        & \textcolor{structure}{black}
-	        & Main Environments\\
+          & \textcolor{structure}{green} 
+          & \textcolor{structure}{cyan} 
+          & \textcolor{structure}{blue} 
+          & \textcolor{structure}{gray} 
+          & \textcolor{structure}{black}
+          & Main Environments\\
 \midrule
 structure & \colorDemo{structure}
-  				& \colorDemo{structure}
-  				& \colorDemo{structure} 
-  				& \colorDemo{structure} 
-  				& \colorDemo{structure} 
-				& chapter  section  subsection \\
+          & \colorDemo{structure}
+          & \colorDemo{structure} 
+          & \colorDemo{structure} 
+          & \colorDemo{structure} 
+          & chapter  section  subsection \\
 main      & \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-  				& \colorDemo{main}
-				& definition  exercise  problem  \\
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & \colorDemo{main}
+          & definition  exercise  problem  \\
 second    & \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-  				& \colorDemo{second}
-				& theorem  lemma  corollary\\
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & \colorDemo{second}
+          & theorem  lemma  corollary\\
 third     & \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-  				& \colorDemo{third}
-				& proposition\\
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & \colorDemo{third}
+          & proposition\\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -325,9 +325,9 @@ Let $z$ be some element of $xH \cap yH$.  Then $z = xa$ for some $a \in H$, and 
 \end{proof}
 
 \begin{figure}[htbp]
-	\centering
-	\includegraphics[width=0.6\textwidth]{scatter.pdf}
-	\caption{Matplotlib: Scatter Plot Example\label{fig:scatter}}
+  \centering
+  \includegraphics[width=0.6\textwidth]{scatter.pdf}
+  \caption{Matplotlib: Scatter Plot Example\label{fig:scatter}}
 \end{figure}
 
 Regression analysis is a powerful statistical method that allows you to examine the relationship between two or more variables of interest. While there are many types of regression analysis, at their core they all examine the influence of one or more independent variables on a dependent variable. The process of performing a regression allows you to confidently determine which factors matter most, which factors can be ignored, and how these factors influence each other.
@@ -360,13 +360,13 @@ Let's continue using our application training example. In this case, we'd want t
 \lipsum[1-2]
 
 \begin{itemize}
-	\item Routing and resource discovery;
-	     \begin{itemize} 
-      	   	\item Language Models
-       	 	\item Vector Space Models
-    		 \end{itemize}
-	\item Resilient and scalable computer networks;
-	\item Distributed storage and search.
+  \item Routing and resource discovery;
+  \begin{itemize} 
+    \item Language Models
+    \item Vector Space Models
+  \end{itemize}
+  \item Resilient and scalable computer networks;
+  \item Distributed storage and search.
 \end{itemize}
 
 

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -91,7 +91,7 @@
 % ----- Handle Colors -----
 
 
-% corlor definition
+% color definition
 \RequirePackage{xcolor}
 
 \newcommand\@color@define{%

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -88,48 +88,60 @@
 \DeclareMathSymbol{\ointop}{\mathop}{CMlargesymbols}{"49}
 \DeclareMathSymbol{\prodop}{\mathop}{CMlargesymbols}{"59}
 
-% ----- Handle Colors -----
 
+%% open latex3 catcode scheme, where 
+%%  - space ( ) is ignored, and
+%%  - colon (:) and underscore (_) are allowed in command names
+\ExplSyntaxOn
+
+% ----- Handle Colors -----
 
 % color definition
 \RequirePackage{xcolor}
 
-\newcommand\@color@define{%
-  \ifdefstring{\ELEGANT@color}{green}{%
-    \definecolor{structure} {RGB}{0,120,2}%
-    \definecolor{main}      {RGB}{0,120,2}%
-    \definecolor{second}    {RGB}{230,90,7}%
-    \definecolor{third}     {RGB}{0,160,152}%
-  }{\relax}%
-  \ifdefstring{\ELEGANT@color}{cyan}{%
-    \definecolor{structure} {RGB}{31,186,190}%
-    \definecolor{main}      {RGB}{59,180,5}%
-    \definecolor{second}    {RGB}{175,153,8}%
-    \definecolor{third}     {RGB}{244,105,102}%
-  }{\relax}%
-  \ifdefstring{\ELEGANT@color}{blue}{%
-    \definecolor{structure} {RGB}{60,113,183}%
-    \definecolor{main}      {RGB}{0,166,82}%
-    \definecolor{second}    {RGB}{255,134,24}%
-    \definecolor{third}     {RGB}{0,174,247}%
-  }{\relax}%
-  \ifdefstring{\ELEGANT@color}{gray}{%
-    \definecolor{structure} {RGB}{100,100,100}%
-    \definecolor{main}      {RGB}{100,100,100}%
-    \definecolor{second}    {RGB}{100,100,100}%
-    \definecolor{third}     {RGB}{100,100,100}%
-  }{\relax}%
-  \ifdefstring{\ELEGANT@color}{black}{%
-    \definecolor{structure} {RGB}{0,0,0}%
-    \definecolor{main}      {RGB}{0,0,0}%
-    \definecolor{second}    {RGB}{0,0,0}%
-    \definecolor{third}     {RGB}{0,0,0}%
-  }{\relax}%
+\newcommand\@color@define{
+  \ifdefstring{\ELEGANT@color}{green}{
+    \definecolor{structure} {RGB}{0,120,2}
+    \definecolor{main}      {RGB}{0,120,2}
+    \definecolor{second}    {RGB}{230,90,7}
+    \definecolor{third}     {RGB}{0,160,152}
+  }{\relax}
+  \ifdefstring{\ELEGANT@color}{cyan}{
+    \definecolor{structure} {RGB}{31,186,190}
+    \definecolor{main}      {RGB}{59,180,5}
+    \definecolor{second}    {RGB}{175,153,8}
+    \definecolor{third}     {RGB}{244,105,102}
+  }{\relax}
+  \ifdefstring{\ELEGANT@color}{blue}{
+    \definecolor{structure} {RGB}{60,113,183}
+    \definecolor{main}      {RGB}{0,166,82}
+    \definecolor{second}    {RGB}{255,134,24}
+    \definecolor{third}     {RGB}{0,174,247}
+  }{\relax}
+  \ifdefstring{\ELEGANT@color}{gray}{
+    \definecolor{structure} {RGB}{100,100,100}
+    \definecolor{main}      {RGB}{100,100,100}
+    \definecolor{second}    {RGB}{100,100,100}
+    \definecolor{third}     {RGB}{100,100,100}
+  }{\relax}
+  \ifdefstring{\ELEGANT@color}{black}{
+    \definecolor{structure} {RGB}{0,0,0}
+    \definecolor{main}      {RGB}{0,0,0}
+    \definecolor{second}    {RGB}{0,0,0}
+    \definecolor{third}     {RGB}{0,0,0}
+  }{\relax}
+  
+  \colorlet{demo}{structure}
 }
 \@color@define
 
 \definecolor{winered}       {rgb}{0.5,0,0}
 \definecolor{bule}          {RGB}{18,29,57}
+
+
+%% close latex3 catcode scheme
+\ExplSyntaxOff
+
 
 %% 章节以及页脚图形
 \newcommand{\base}[2]{%
@@ -733,7 +745,7 @@
 \newcommand*\colorsetDemo[1]{%
   \begingroup
   \@color@updateColorset{#1}%
-  \textcolor{structure}{\lstinline{#1}}%
+  \textcolor{demo}{\lstinline{#1}}%
   \endgroup
 }
 

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -53,9 +53,6 @@
 \ProcessKeyvalOptions*\relax
 \LoadClass[a4paper,oneside,openany]{book}
 
-\RequirePackage{comment}
-
-
 
 % fontsetting
 
@@ -77,7 +74,7 @@
 \RequirePackage{newtxmath}
 \RequirePackage{anyfontsize}
 
-\DeclareSymbolFont{CMlargesymbols}{OMX}{cmex}{m}{n}%
+\DeclareSymbolFont{CMlargesymbols}{OMX}{cmex}{m}{n}
 
 \let\intop\relax
 \let\sumop\relax
@@ -136,7 +133,6 @@
 \@color@define
 
 \definecolor{winered}       {rgb}{0.5,0,0}
-\definecolor{bule}          {RGB}{18,29,57}
 
 
 %% close latex3 catcode scheme

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -24,27 +24,27 @@
 \DeclareStringOption[hang]{titlestyle}[hang]
 
 % ----- backward compatibility
-\DeclareVoidOption{green}{\ekv{color = green}}
-\DeclareVoidOption{cyan}{\ekv{color = cyan}}
-\DeclareVoidOption{blue}{\ekv{color = blue}}
-\DeclareVoidOption{gray}{\ekv{color = gray}}
-\DeclareVoidOption{black}{\ekv{color = black}}
-\DeclareVoidOption{nocolor}{\ekv{color = none}}
+\DeclareVoidOption{green}{\ekv{color=green}}
+\DeclareVoidOption{cyan}{\ekv{color=cyan}}
+\DeclareVoidOption{blue}{\ekv{color=blue}}
+\DeclareVoidOption{gray}{\ekv{color=gray}}
+\DeclareVoidOption{black}{\ekv{color=black}}
+\DeclareVoidOption{nocolor}{\ekv{color=none}}
 
 \DeclareVoidOption{en}{\ekv{lang=en}}
 \DeclareVoidOption{cn}{\ekv{lang=cn}}
 
-\DeclareVoidOption{answer}{\ekv{result = answer}}
-\DeclareVoidOption{noanswer}{\ekv{result = noanswer}}
+\DeclareVoidOption{answer}{\ekv{result=answer}}
+\DeclareVoidOption{noanswer}{\ekv{result=noanswer}}
 
 \DeclareVoidOption{fancy}{\ekv{mode=fancy}}
 \DeclareVoidOption{simple}{\ekv{mode=simple}}
 
-\DeclareVoidOption{hide}{\ekv{base = hide}}
-\DeclareVoidOption{show}{\ekv{base = show}}
+\DeclareVoidOption{hide}{\ekv{base=hide}}
+\DeclareVoidOption{show}{\ekv{base=show}}
 
-\DeclareVoidOption{hang}{\ekv{titlestyle = hang}}
-\DeclareVoidOption{display}{\ekv{titlestyle = display}}
+\DeclareVoidOption{hang}{\ekv{titlestyle=hang}}
+\DeclareVoidOption{display}{\ekv{titlestyle=display}}
 
 
 % ----- Default Options -----
@@ -68,9 +68,9 @@
 
 % font setting for text and math
 \ifxetex
-	\RequirePackage{fontenc}
+  \RequirePackage{fontenc}
 \else
-	\RequirePackage[T1]{fontenc}
+  \RequirePackage[T1]{fontenc}
 \fi
 
 \RequirePackage{newtxtext}
@@ -96,34 +96,34 @@
 
 \newcommand\@color@define{%
   \ifdefstring{\ELEGANT@color}{green}{%
-  	\definecolor{structure} {RGB}{0,120,2}%
-  	\definecolor{main}      {RGB}{0,120,2}%
-  	\definecolor{second}    {RGB}{230,90,7}%
-  	\definecolor{third}     {RGB}{0,160,152}%
+    \definecolor{structure} {RGB}{0,120,2}%
+    \definecolor{main}      {RGB}{0,120,2}%
+    \definecolor{second}    {RGB}{230,90,7}%
+    \definecolor{third}     {RGB}{0,160,152}%
   }{\relax}%
   \ifdefstring{\ELEGANT@color}{cyan}{%
-  	\definecolor{structure} {RGB}{31,186,190}%
-  	\definecolor{main}      {RGB}{59,180,5}%
-  	\definecolor{second}    {RGB}{175,153,8}%
-  	\definecolor{third}     {RGB}{244,105,102}%
+    \definecolor{structure} {RGB}{31,186,190}%
+    \definecolor{main}      {RGB}{59,180,5}%
+    \definecolor{second}    {RGB}{175,153,8}%
+    \definecolor{third}     {RGB}{244,105,102}%
   }{\relax}%
   \ifdefstring{\ELEGANT@color}{blue}{%
-  	\definecolor{structure} {RGB}{60,113,183}%
-  	\definecolor{main}      {RGB}{0,166,82}%
-  	\definecolor{second}    {RGB}{255,134,24}%
-  	\definecolor{third}     {RGB}{0,174,247}%
+    \definecolor{structure} {RGB}{60,113,183}%
+    \definecolor{main}      {RGB}{0,166,82}%
+    \definecolor{second}    {RGB}{255,134,24}%
+    \definecolor{third}     {RGB}{0,174,247}%
   }{\relax}%
   \ifdefstring{\ELEGANT@color}{gray}{%
-  	\definecolor{structure} {RGB}{100,100,100}%
-  	\definecolor{main}      {RGB}{100,100,100}%
-  	\definecolor{second}    {RGB}{100,100,100}%
-  	\definecolor{third}     {RGB}{100,100,100}%
+    \definecolor{structure} {RGB}{100,100,100}%
+    \definecolor{main}      {RGB}{100,100,100}%
+    \definecolor{second}    {RGB}{100,100,100}%
+    \definecolor{third}     {RGB}{100,100,100}%
   }{\relax}%
   \ifdefstring{\ELEGANT@color}{black}{%
-  	\definecolor{structure} {RGB}{0,0,0}%
-  	\definecolor{main}      {RGB}{0,0,0}%
-  	\definecolor{second}    {RGB}{0,0,0}%
-  	\definecolor{third}     {RGB}{0,0,0}%
+    \definecolor{structure} {RGB}{0,0,0}%
+    \definecolor{main}      {RGB}{0,0,0}%
+    \definecolor{second}    {RGB}{0,0,0}%
+    \definecolor{third}     {RGB}{0,0,0}%
   }{\relax}%
 }
 \@color@define
@@ -133,17 +133,17 @@
 
 %% 章节以及页脚图形
 \newcommand{\base}[2]{%
-	\nointerlineskip \vspace{0.1\baselineskip}\hspace{\fill}
-	{\color{#1}
-		\resizebox{0.3\linewidth}{1.5ex}
-		{{%
-				{\begin{tikzpicture}
-					\node  (C) at (0,0) {};
-					\node (D) at (4,0) {};
-					\path (C) to [ornament=#2] (D);
-					\end{tikzpicture}}}}}%
-	\hspace{\fill}
-	\par\nointerlineskip \vspace{0.1\baselineskip}
+  \nointerlineskip \vspace{0.1\baselineskip}\hspace{\fill}
+  {\color{#1}
+    \resizebox{0.3\linewidth}{1.5ex}
+    {{%
+        {\begin{tikzpicture}
+          \node  (C) at (0,0) {};
+          \node (D) at (4,0) {};
+          \path (C) to [ornament=#2] (D);
+          \end{tikzpicture}}}}}%
+  \hspace{\fill}
+  \par\nointerlineskip \vspace{0.1\baselineskip}
 }
 
 % ----- Math option -----
@@ -173,7 +173,7 @@
 
 % caption settings 
 \RequirePackage{caption}
-\captionsetup{labelfont = bf}
+\captionsetup{labelfont=bf}
 \RequirePackage[font=small,labelfont={bf,color=structure}]{caption} 
 \captionsetup[table]{skip=3pt}
 \captionsetup[figure]{skip=3pt}
@@ -254,30 +254,30 @@
 
 \RequirePackage{geometry}
 \geometry{
-	a4paper,
-	top=25.4mm, bottom=25.4mm,
-	headheight=2.17cm,
-	headsep=4mm,
-	footskip=12mm
+  a4paper,
+  top=25.4mm, bottom=25.4mm,
+  headheight=2.17cm,
+  headsep=4mm,
+  footskip=12mm
 }
 
 
 \RequirePackage{hyperref}
 \hypersetup{
-	breaklinks,
-	unicode,
-	linktoc=all,
-	bookmarksnumbered=true,
-	bookmarksopen=true,
-	pdfkeywords={ElegantBook},
-	colorlinks,
-	linkcolor=winered,
-	citecolor=winered,
-	urlcolor  = winered,
-	plainpages=false,
-	pdfstartview=FitH,
-	pdfborder={0 0 0},
-	linktocpage
+  breaklinks,
+  unicode,
+  linktoc=all,
+  bookmarksnumbered=true,
+  bookmarksopen=true,
+  pdfkeywords={ElegantBook},
+  colorlinks,
+  linkcolor=winered,
+  citecolor=winered,
+  urlcolor =winered,
+  plainpages=false,
+  pdfstartview=FitH,
+  pdfborder={0 0 0},
+  linktocpage
 }
 \let\email\relax
 \newcommand\email[1]{\href{mailto:#1}{\nolinkurl{#1}}}
@@ -372,23 +372,23 @@
   }
   
   \newtcbtheorem[auto counter,number within=chapter]{definition}{
-  	\ifdefstring{\ELEGANT@lang}{en}{Definition}{定义}
+    \ifdefstring{\ELEGANT@lang}{en}{Definition}{定义}
   }{defstyle}{def}
   
   \newtcbtheorem[auto counter,number within=chapter]{theorem}{
-  	\ifdefstring{\ELEGANT@lang}{en}{Theorem}{定理}
+    \ifdefstring{\ELEGANT@lang}{en}{Theorem}{定理}
   }{thmstyle}{thm}
   
   \newtcbtheorem[auto counter,number within=chapter]{proposition}{
-  	\ifdefstring{\ELEGANT@lang}{en}{Proposition}{命题}
+    \ifdefstring{\ELEGANT@lang}{en}{Proposition}{命题}
   }{propstyle}{pro}
   
   \newtcbtheorem[auto counter,number within=chapter]{corollary}{
-  	\ifdefstring{\ELEGANT@lang}{en}{Corollary}{推论}
+    \ifdefstring{\ELEGANT@lang}{en}{Corollary}{推论}
   }{thmstyle}{cor}
   
   \newtcbtheorem[auto counter,number within=chapter]{lemma}{
-  	\ifdefstring{\ELEGANT@lang}{en}{Lemma}{引理}
+    \ifdefstring{\ELEGANT@lang}{en}{Lemma}{引理}
   }{thmstyle}{lem}
 
 }{\relax}
@@ -470,104 +470,104 @@
 \setcounter{exam}{0}
 \renewcommand{\theexam}{\thechapter.\arabic{exam}}
 \newenvironment{example}[1][]{
- 		\refstepcounter{exam}\par\noindent\textbf{\color{main}{
- 			\ifdefstring{\ELEGANT@lang}{en}{Example}{例}
- 		}\theexam #1 }\rmfamily %
- 	}{
- 		\par\medskip\ignorespacesafterend %
- 	}
+  \refstepcounter{exam}\par\noindent\textbf{\color{main}{
+    \ifdefstring{\ELEGANT@lang}{en}{Example}{例}
+  }\theexam #1 }\rmfamily %
+}{
+  \par\medskip\ignorespacesafterend %
+}
 
 %% Exercise with counter
 \newcounter{exer}[chapter]
 \setcounter{exer}{0}
 \renewcommand{\theexer}{\thechapter.\arabic{exer}}
 \newenvironment{exercise}[1][]{
- 		\refstepcounter{exer}\par\noindent\makebox[-3pt][r]{\scriptsize\color{red!90}\HandPencilLeft\quad}\textbf{\color{main}{
- 			\ifdefstring{\ELEGANT@lang}{en}{Exercise}{练习}
- 		}\theexer #1 }\rmfamily %
- 	}{
- 		\par\medskip\ignorespacesafterend %
- 	}
+  \refstepcounter{exer}\par\noindent\makebox[-3pt][r]{\scriptsize\color{red!90}\HandPencilLeft\quad}\textbf{\color{main}{
+    \ifdefstring{\ELEGANT@lang}{en}{Exercise}{练习}
+  }\theexer #1 }\rmfamily %
+}{
+  \par\medskip\ignorespacesafterend %
+}
 
 %% Exercise with counter
 \newcounter{prob}[chapter]
 \setcounter{prob}{0}
 \renewcommand{\theprob}{\thechapter.\arabic{prob}}
 \newenvironment{problem}[1][]{
- 		\refstepcounter{prob}\par\noindent\textbf{\color{main}{%
- 			\ifdefstring{\ELEGANT@lang}{en}{Problem}{例题}
- 		}\theprob #1 }\rmfamily %
- 	}{
- 		\par\medskip\ignorespacesafterend %
- 	}
+  \refstepcounter{prob}\par\noindent\textbf{\color{main}{%
+    \ifdefstring{\ELEGANT@lang}{en}{Problem}{例题}
+  }\theprob #1 }\rmfamily %
+}{
+  \par\medskip\ignorespacesafterend %
+}
 
 
 
 \newenvironment{note}{\par\noindent{\makebox[0pt][r]{\scriptsize\color{red!90}\textdbend\quad}\textbf{\color{second}
-	\ifdefstring{\ELEGANT@lang}{en}{Note}{注意}
+  \ifdefstring{\ELEGANT@lang}{en}{Note}{注意}
 }}\ifdefstring{\ELEGANT@lang}{en}{\itshape}{\kaishu}}{\par}
 
 \newenvironment{proof}{\par\noindent\textbf{\color{second}
-	\ifdefstring{\ELEGANT@lang}{en}{Proof}{证明}
+  \ifdefstring{\ELEGANT@lang}{en}{Proof}{证明}
 }\color{black!90}\small}{
 %\hfill$\Box$\quad
 \par}
 \newenvironment{remark}{\noindent\textbf{\color{second}
-	\ifdefstring{\ELEGANT@lang}{en}{Remark}{注}
+  \ifdefstring{\ELEGANT@lang}{en}{Remark}{注}
 }}{\par}
 \newenvironment{assumption}{\par\noindent\textbf{\color{third}
-	\ifdefstring{\ELEGANT@lang}{en}{Assumption}{假设}
+  \ifdefstring{\ELEGANT@lang}{en}{Assumption}{假设}
 }}{\par}
 \newenvironment{conclusion}{\par\noindent\textbf{\color{third}
-	\ifdefstring{\ELEGANT@lang}{en}{Conclusion}{结论}
+  \ifdefstring{\ELEGANT@lang}{en}{Conclusion}{结论}
 }}{\par}
 \newenvironment{solution}{\par\noindent\textbf{\color{main}
-	\ifdefstring{\ELEGANT@lang}{en}{Solution}{解}
+  \ifdefstring{\ELEGANT@lang}{en}{Solution}{解}
 }}{\par}
 \newenvironment{property}{\par\noindent\textbf{\color{third}
-	\ifdefstring{\ELEGANT@lang}{en}{Property}{性质}
+  \ifdefstring{\ELEGANT@lang}{en}{Property}{性质}
 }}{\par}
 \newenvironment{custom}[1]{\par\noindent\textbf{\color{third}
-	\ifdefstring{\ELEGANT@lang}{en}{#1}{#1}
+  \ifdefstring{\ELEGANT@lang}{en}{#1}{#1}
 }}{\par}
 
 \RequirePackage{multicol}
 \tcbset{
-    introduction/.style={
-        enhanced,
-		breakable,
-		colback=structure!10,
-		colframe=structure,
-  		fonttitle=\bfseries,
-  		colbacktitle=structure,
-  		fontupper=\ifdefstring{\ELEGANT@lang}{en}{\sffamily}{\kaishu},
-  		attach boxed title to top center={yshift=-3mm,yshifttext=-1mm},
-  		boxrule=0pt,
-  		toprule=0.5pt,
-  		bottomrule=0.5pt,
-  		top=8pt,
-  		before skip=8pt,
-  		sharp corners
-    },
+  introduction/.style={
+    enhanced,
+    breakable,
+    colback=structure!10,
+    colframe=structure,
+    fonttitle=\bfseries,
+    colbacktitle=structure,
+    fontupper=\ifdefstring{\ELEGANT@lang}{en}{\sffamily}{\kaishu},
+    attach boxed title to top center={yshift=-3mm,yshifttext=-1mm},
+    boxrule=0pt,
+    toprule=0.5pt,
+    bottomrule=0.5pt,
+    top=8pt,
+    before skip=8pt,
+    sharp corners
+  },
 }
 
 \newenvironment{introduction}[1][\ifdefstring{\ELEGANT@lang}{en}{Introduction}{内容提要}]{
-	\begin{tcolorbox}[introduction,title={#1}]
-	\begin{multicols}{2}
-	\begin{itemize}[label=\textcolor{structure}{\scriptsize\SquareShadowBottomRight}]
-	}{%
-	\end{itemize}
-	\end{multicols}
-	\end{tcolorbox}
+  \begin{tcolorbox}[introduction,title={#1}]
+  \begin{multicols}{2}
+  \begin{itemize}[label=\textcolor{structure}{\scriptsize\SquareShadowBottomRight}]
+}{%
+  \end{itemize}
+  \end{multicols}
+  \end{tcolorbox}
 }
 
 
 \ifdefstring{\ELEGANT@result}{noanswer}{
-	\AtBeginDocument{
-	\excludecomment{solution}
-	\excludecomment{proof}
-	\excludecomment{inline}
-	}
+  \AtBeginDocument{
+    \excludecomment{solution}
+    \excludecomment{proof}
+    \excludecomment{inline}
+  }
 }{\relax}
 
 
@@ -641,13 +641,13 @@
 \renewcommand*{\maketitle}{%
   \hypersetup{pageanchor=false}%
   \begin{titlepage}
-  	\newgeometry{margin = 0in}%
-  	\setlength\parindent{0pt}%
+    \newgeometry{margin=0in}%
+    \setlength\parindent{0pt}%
     % cover image
-  	\@cover
+    \@cover
     \par
     % rule in color "second"
-  	\begingroup
+    \begingroup
       \setlength{\fboxsep}{0pt}%
       \color{second}%
       \rule{\linewidth}{0.5in}%
@@ -655,7 +655,7 @@
     \par
     % main title
     \vspace{1.5cm}\hspace*{2em}%
-  	\parbox{0.8\textwidth}{\bfseries\Huge \@title}
+    \parbox{0.8\textwidth}{\bfseries\Huge \@title}
     \par
     % subtitle
     \vspace{.8cm}\hspace{2.5em}%
@@ -664,25 +664,25 @@
     \par
     % meta info
     \vspace{.8cm}\hspace{3.5em}%
-   	\begin{minipage}{0.67\linewidth}
+    \begin{minipage}{0.67\linewidth}
       \linespread{1.5}\selectfont
-   		\color{gray}\normalsize
-   		\renewcommand{\arraystretch}{0.618}
+      \color{gray}\normalsize
+      \renewcommand{\arraystretch}{0.618}
       \@printMetaInfoItem{author}
       \@printMetaInfoItem{institute}
       \@printMetaInfoItem{date}
       \@printMetaInfoItem{version}
-   	\end{minipage}
+    \end{minipage}
     \par
     % logo, put on absolute coordinates
-   	\begin{tikzpicture}[remember picture,overlay]
-		  \node[opacity=0.8,anchor=south east, inner sep=0pt] 
+    \begin{tikzpicture}[remember picture,overlay]
+      \node[opacity=0.8,anchor=south east, inner sep=0pt] 
         at ($(current page.south east) + (-0.8in, 1.5in)$) {\@logo};
-   	\end{tikzpicture}
+    \end{tikzpicture}
     % equote
-  	\vfill
-  	\centerline{\itshape \@equote}
-  	\vspace{1.5cm}
+    \vfill
+    \centerline{\itshape \@equote}
+    \vspace{1.5cm}
   \end{titlepage}
   \restoregeometry
   \thispagestyle{empty}
@@ -704,20 +704,20 @@
 \definecolor{lightgrey}{rgb}{0.9,0.9,0.9}
 \definecolor{frenchplum}{RGB}{190,20,83}
 \lstset{language=[LaTeX]TeX,
-	texcsstyle=*\color{winered},
-	numbers=none,
-	breaklines=true,
-	keywordstyle=\color{winered},
-	commentstyle=\color{gray},
-	emph={elegantpaper,fontenc,fontspec,xeCJK,FiraMono,xunicode,newtxmath,figure,fig,image,img,table,itemize,enumerate,newtxtext,newtxtt,ctex,microtype,description,times,newtx,booktabs,tabular,PDFLaTeX,XeLaTeX,type1cm,BibTeX,device,color,mode,lang,amsthm,tcolorbox,titlestyle},
-	emphstyle={\color{frenchplum}},
-	morekeywords={DeclareSymbolFont,SetSymbolFont,toprule,midrule,bottomrule,institute,version,includegraphics,setmainfont,setsansfont,setmonofont ,setCJKmainfont,setCJKsansfont,setCJKmonofont,RequirePackage,figref,tabref,email,maketitle,keywords,definecolor,equote,logo,cover,subtitle,appendix,chapter,hypersetup,mainmatter,tableofcontents},
-	frame=single,
-	tabsize=2,
-	rulecolor=\color{structure},
-	framerule=0.2pt,
-	columns=flexible,
-	% backgroundcolor=\color{lightgrey}
+  texcsstyle=*\color{winered},
+  numbers=none,
+  breaklines=true,
+  keywordstyle=\color{winered},
+  commentstyle=\color{gray},
+  emph={elegantpaper,fontenc,fontspec,xeCJK,FiraMono,xunicode,newtxmath,figure,fig,image,img,table,itemize,enumerate,newtxtext,newtxtt,ctex,microtype,description,times,newtx,booktabs,tabular,PDFLaTeX,XeLaTeX,type1cm,BibTeX,device,color,mode,lang,amsthm,tcolorbox,titlestyle},
+  emphstyle={\color{frenchplum}},
+  morekeywords={DeclareSymbolFont,SetSymbolFont,toprule,midrule,bottomrule,institute,version,includegraphics,setmainfont,setsansfont,setmonofont ,setCJKmainfont,setCJKsansfont,setCJKmonofont,RequirePackage,figref,tabref,email,maketitle,keywords,definecolor,equote,logo,cover,subtitle,appendix,chapter,hypersetup,mainmatter,tableofcontents},
+  frame=single,
+  tabsize=2,
+  rulecolor=\color{structure},
+  framerule=0.2pt,
+  columns=flexible,
+  % backgroundcolor=\color{lightgrey}
 }
 
 %% helper commands used in manual


### PR DESCRIPTION
Main changes
 - keep 2-space indent
 - add color `demo`, used only for showing demo color of color theme
 - use latex3 catcode scheme for color def lines, in order to omit end line `%` symbols
 - small cleaning up