### PR TITLE
delete duplicate package loading

### DIFF
--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -216,8 +216,6 @@
 \setlist{nolistsep}
 
 % caption settings 
-\RequirePackage{caption}
-\captionsetup{labelfont = bf}
 \RequirePackage[font=small,labelfont={bf,color=structurecolor}]{caption} 
 \captionsetup[table]{skip=3pt}
 \captionsetup[figure]{skip=3pt}

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -351,9 +351,6 @@
 
 %%define the note and proof environment
 \RequirePackage{pifont,manfnt,bbding}
-% list/itemize/enumerate setting
-\RequirePackage[shortlabels]{enumitem}
-\setlist{nolistsep}
 
 
 \RequirePackage[many]{tcolorbox}


### PR DESCRIPTION
Currently, the `.cls` file loads package `enumitem` twice. The first commit of this pull request deletes the second inclusion.

Lines below shows the source code before the first commit:
https://github.com/ElegantLaTeX/ElegantBook/blob/0752a76fd537713ecffbb5e4407820862acbff35/elegantbook.cls#L214-L216
https://github.com/ElegantLaTeX/ElegantBook/blob/0752a76fd537713ecffbb5e4407820862acbff35/elegantbook.cls#L354-L356