### PR TITLE
Fixed the "microgap" between the image and the color line on the cover page

### DIFF
--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -1296,8 +1296,8 @@
       \includegraphics[trim=0 26bp 0 26bp,clip=true, width=\linewidth]{example-image}
     \fi
   }{\relax}
-  \setlength{\fboxsep}{0pt}
-  \colorbox{coverlinecolor}{\makebox[\linewidth][c]{\shortstack[c]{\vspace{0.5in}}}}
+  \vskip-\baselineskip
+  {\color{coverlinecolor}\hrule width \linewidth height .5in}
   \vfill
   \vskip-2ex
   \hspace{2em}

--- a/elegantbook.cls
+++ b/elegantbook.cls
@@ -1297,7 +1297,7 @@
     \fi
   }{\relax}
   \vskip-\baselineskip
-  {\color{coverlinecolor}\hrule width \linewidth height .5in}
+  {\color{coverlinecolor}\hrule \@width \linewidth \@height .5in}
   \vfill
   \vskip-2ex
   \hspace{2em}


### PR DESCRIPTION
The line
```tex
\colorbox{coverlinecolor}{\makebox[\linewidth][c]{\shortstack[c]{\vspace{0.5in}}}}
```
or equivalently, if one use
```tex
\color{coverlinecolor}\rule{\linewidth}{.5in}
```
there will always a gap between the image and the color line. Since they both based on the primitive `\vrule`.

Just use `\hrule`, and there will be a `\baselineskip` gap before it, and use `\vskip` to remove it, the image and the colorline can be attached **perfectly**, with 0% deviation.

See the following screenshot.

<img width="2240" height="1260" alt="image" src="https://github.com/user-attachments/assets/50efaa5e-567e-42be-978e-a4584e2fd473" />
